### PR TITLE
Fix calling undefined errCallback, and fallback to original attach method

### DIFF
--- a/src/channel/ably/attach.ts
+++ b/src/channel/ably/attach.ts
@@ -24,7 +24,7 @@ export const beforeChannelAttach = (ablyClient, authorize: Function) => {
 
         authorize(this, (error) => {
             this.authorizing = false;
-            if (error) {
+            if (error && errCallback) {
                 errCallback(error);
                 return;
             } else {


### PR DESCRIPTION
Fixed https://github.com/ably-forks/laravel-echo/issues/29

In the core Ably js client, there are cases where the attach method is called without an errCallback. With the proposed fix, we'll check if an errCallback has been passed, and if not, defer to the original attach method, which will perform some logging. At this point in time, I couldn't see any cases where _attach is called with forceReattach = true and errCallback = undefined, so we should end here:

https://github.com/ably/ably-js/blob/fdd5a566eafac0a7fae9592f890361a608794487/src/common/lib/client/realtimechannel.ts#L342-L346C6