### PR TITLE
[ECO-4995] Fix base64 url encoding/decoding

### DIFF
--- a/src/channel/ably/utils.ts
+++ b/src/channel/ably/utils.ts
@@ -33,18 +33,37 @@ export const toTokenDetails = (jwtToken: string): TokenDetails | any => {
 
 const isBrowser = typeof window === 'object';
 
+/**
+ * Helper method to decode base64 url encoded string
+ * https://stackoverflow.com/a/78178053
+ * @param base64 base64 url encoded string
+ * @returns decoded text string
+ */
 export const toText = (base64: string) => {
+    const base64Encoded = base64.replace(/-/g, '+').replace(/_/g, '/');
+    const padding = base64.length % 4 === 0 ? '' : '='.repeat(4 - (base64.length % 4));
+    const base64WithPadding = base64Encoded + padding;
+
     if (isBrowser) {
-        return atob(base64);
+        return atob(base64WithPadding);
     }
-    return Buffer.from(base64, 'base64').toString('binary');
+    return Buffer.from(base64WithPadding, 'base64').toString('binary');
 };
 
+/**
+ * Helper method to encode text into base64 url encoded string
+ * https://stackoverflow.com/a/78178053
+ * @param base64 text
+ * @returns base64 url encoded string
+ */
 export const toBase64 = (text: string) => {
+    let encoded = ''
     if (isBrowser) {
-        return btoa(text);
+        encoded = btoa(text);
+    } else {
+        encoded = Buffer.from(text, 'binary').toString('base64');
     }
-    return Buffer.from(text, 'binary').toString('base64');
+    return encoded.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 };
 
 const isAbsoluteUrl = (url: string) => (url && url.indexOf('http://') === 0) || url.indexOf('https://') === 0;

--- a/src/channel/ably/utils.ts
+++ b/src/channel/ably/utils.ts
@@ -12,11 +12,11 @@ export const parseJwt = (jwtToken: string): { header: any; payload: any } => {
     // Get Token Header
     const base64HeaderUrl = jwtToken.split('.')[0];
     const base64Header = base64HeaderUrl.replace('-', '+').replace('_', '/');
-    const header = JSON.parse(toText(base64Header));
+    const header = JSON.parse(fromBase64UrlEncoded(base64Header));
     // Get Token payload
     const base64Url = jwtToken.split('.')[1];
     const base64 = base64Url.replace('-', '+').replace('_', '/');
-    const payload = JSON.parse(toText(base64));
+    const payload = JSON.parse(fromBase64UrlEncoded(base64));
     return { header, payload };
 };
 
@@ -39,7 +39,7 @@ const isBrowser = typeof window === 'object';
  * @param base64 base64 url encoded string
  * @returns decoded text string
  */
-export const toText = (base64: string) => {
+export const fromBase64UrlEncoded = (base64: string) => {
     const base64Encoded = base64.replace(/-/g, '+').replace(/_/g, '/');
     const padding = base64.length % 4 === 0 ? '' : '='.repeat(4 - (base64.length % 4));
     const base64WithPadding = base64Encoded + padding;
@@ -56,7 +56,7 @@ export const toText = (base64: string) => {
  * @param base64 text
  * @returns base64 url encoded string
  */
-export const toBase64 = (text: string) => {
+export const toBase64UrlEncoded = (text: string) => {
     let encoded = ''
     if (isBrowser) {
         encoded = btoa(text);

--- a/src/connector/ably-connector.ts
+++ b/src/connector/ably-connector.ts
@@ -2,7 +2,7 @@ import { Connector } from './connector';
 
 import { AblyChannel, AblyPrivateChannel, AblyPresenceChannel, AblyAuth } from './../channel';
 import { AblyRealtime, TokenDetails } from '../../typings/ably';
-import { toBase64 } from '../channel/ably/utils';
+import { toBase64UrlEncoded } from '../channel/ably/utils';
 
 /**
  * This class creates a connector to Ably.
@@ -126,7 +126,7 @@ export class AblyConnector extends Connector {
             connectionKey : this.ably.connection.key,
             clientId : this.ably.auth.clientId ?? null,
         }
-        return toBase64(JSON.stringify(socketIdObject));
+        return toBase64UrlEncoded(JSON.stringify(socketIdObject));
     }
 
     /**

--- a/src/connector/ably-connector.ts
+++ b/src/connector/ably-connector.ts
@@ -119,7 +119,7 @@ export class AblyConnector extends Connector {
 
     /**
      * Get the socket ID for the connection.
-     * For ably, returns base64 encoded json with keys {connectionKey, clientId}
+     * For ably, returns base64 url encoded json with keys {connectionKey, clientId}
      */
     socketId(): string {
         let socketIdObject = {

--- a/src/echo.ts
+++ b/src/echo.ts
@@ -117,7 +117,7 @@ export default class Echo {
 
     /**
      * Get the Socket ID for the connection.
-     * For ably, returns base64 encoded json with keys {connectionKey, clientId}
+     * For ably, returns base64 url encoded json with keys {connectionKey, clientId}
      */
     socketId(): string {
         return this.connector.socketId();


### PR DESCRIPTION
- Fixed https://github.com/ably/laravel-broadcaster/issues/51
- Server sends base64 url encoded JWT, parser needs to use base64 url decoding, instead of normal base64 decoding.
- https://gist.github.com/tatsuyasusukida/ce71456081748242a0bd4cbfcfe44eb7